### PR TITLE
fix: don't add struct and enum name to NameTranslator

### DIFF
--- a/src/hirgen/decl.cc
+++ b/src/hirgen/decl.cc
@@ -11,13 +11,9 @@ void DeclVarReg::Visit(const ast::FunctionDeclaration &decl) {
     ctx_.translator().RegNameRaw(decl.name().name());
 }
 
-void DeclVarReg::Visit(const ast::StructDeclaration &decl) {
-    ctx_.translator().RegNameRaw(decl.name().name());
-}
+void DeclVarReg::Visit(const ast::StructDeclaration &) {}
 
-void DeclVarReg::Visit(const ast::EnumDeclaration &decl) {
-    ctx_.translator().RegNameRaw(decl.name().name());
-}
+void DeclVarReg::Visit(const ast::EnumDeclaration &) {}
 
 void DeclHirGen::Visit(const ast::FunctionDeclaration &decl) {
     hir::FunctionDeclarationName name(
@@ -88,9 +84,8 @@ void DeclHirGen::Visit(const ast::StructDeclaration &decl) {
         fields.emplace_back(gen.type(), std::move(name), field.span());
     }
 
-    hir::StructDeclarationName name(
-        std::string(ctx_.translator().Translate(decl.name().name())),
-        decl.name().span());
+    hir::StructDeclarationName name(std::string(decl.name().name()),
+                                    decl.name().span());
     decl_ = std::make_unique<hir::StructDeclaration>(
         std::move(name), std::move(fields), decl.span());
     success_ = true;
@@ -133,9 +128,8 @@ void DeclHirGen::Visit(const ast::EnumDeclaration &decl) {
         base_type.emplace(type);
     }
 
-    hir::EnumDeclarationName name(
-        std::string(ctx_.translator().Translate(decl.name().name())),
-        decl.name().span());
+    hir::EnumDeclarationName name(std::string(decl.name().name()),
+                                  decl.name().span());
     decl_ = std::make_unique<hir::EnumDeclaration>(
         std::move(name), base_type.value(), std::move(fields), decl.span());
     success_ = true;

--- a/src/hirgen/expr.cc
+++ b/src/hirgen/expr.cc
@@ -227,13 +227,8 @@ void ExprHirGen::Visit(const ast::StructExpression &expr) {
         inits.emplace_back(std::move(name), std::move(gen.expr_));
     }
 
-    if (!ctx_.translator().Translatable(expr.name().name())) {
-        ReportInfo info(expr.span(), "no such name exists", "");
-        Report(ctx_.ctx(), ReportLevel::Error, info);
-        return;
-    }
-    auto translated = ctx_.translator().Translate(expr.name().name());
-    hir::StructExpressionName name(std::move(translated), expr.name().span());
+    hir::StructExpressionName name(std::string(expr.name().name()),
+                                   expr.name().span());
 
     expr_ = std::make_unique<hir::StructExpression>(
         std::move(name), std::move(inits), expr.span());

--- a/src/hirgen/type.cc
+++ b/src/hirgen/type.cc
@@ -66,14 +66,8 @@ void TypeHirGen::Visit(const ast::ArrayType &type) {
 }
 
 void TypeHirGen::Visit(const ast::NameType &type) {
-    if (!ctx_.translator().Translatable(type.name())) {
-        ReportInfo info(type.span(), "no such name exists", "");
-        Report(ctx_.ctx(), ReportLevel::Error, info);
-        return;
-    }
-
-    type_ = std::make_shared<hir::NameType>(
-        std::string(ctx_.translator().Translate(type.name())), type.span());
+    type_ =
+        std::make_shared<hir::NameType>(std::string(type.name()), type.span());
     success_ = true;
 }
 


### PR DESCRIPTION
Closes #4 